### PR TITLE
Fixed InvalidOperationException on restore of process that has exited.

### DIFF
--- a/GameOptimizer/GameOptimizer/Optimizer.cs
+++ b/GameOptimizer/GameOptimizer/Optimizer.cs
@@ -233,6 +233,10 @@ namespace GameOptimizer
 
             foreach (ProcessStateChange change in _changedProcesses)
             {
+                // If the process has exited there is no reason to continue as it will just throw an exception.
+                if (change.ChangedProcess.HasExited)
+                    continue;
+
                 try
                 {
                     if (change.PreChangePriority != null)


### PR DESCRIPTION
Fixes Issue #8 

The Restore function now checks whether the process `HasExited` before continuing to attempt to restore its priority/affinity; previous implementation would throw an InvalidOperationException as the process was no longer valid.